### PR TITLE
Added Windows 8.1 support

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -448,6 +448,7 @@
           // http://msdn.microsoft.com/en-us/library/ms537503(VS.85).aspx
           // http://web.archive.org/web/20081122053950/http://msdn.microsoft.com/en-us/library/ms537503(VS.85).aspx
           data = {
+            '6.3':  '8.1', 
             '6.2':  '8',
             '6.1':  'Server 2008 R2 / 7',
             '6.0':  'Server 2008 / Vista',

--- a/test/testwin81.js
+++ b/test/testwin81.js
@@ -1,0 +1,6 @@
+var platform = require('../platform'),
+	testUA = 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.5 Safari/537.36',
+	parsed = platform.parse(testUA);
+
+console.log(parsed.os.toString());
+console.log(parsed.os.version === '8.1');


### PR DESCRIPTION
Added support for Windows 8.1 (aka NT 6.3) - the test file can be ignored.
