### PR TITLE
Fixing detection of IE 11 masking as Firefox

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -639,7 +639,7 @@
       layout = ['NetFront'];
     }
     // detect IE 11 and above
-    if (!name && layout == 'Trident') {
+    if ((!name || name === 'Firefox') && layout == 'Trident') {
       name = 'IE';
       version = (/\brv:([\d.]+)/.exec(ua) || 0)[1];
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2124,6 +2124,13 @@
       equal(actual.description, expected);
     });
 
+    test('parses IE 11.0 masking as Firefox', function() {
+      var actual = parse('Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko/20100101 Firefox/12.0'),
+          expected = 'IE 11.0 on Windows Server 2008 R2 / 7';
+
+      equal(actual.description, expected);
+    });
+
     test('parses Opera', function() {
       var actual = parse('Opera/9.80 (Macintosh; Intel Mac OS X 10.7.2; U; Edition Next; en) Presto/2.9.220 Version/12.00'),
           expected = 'Opera 12.00 on OS X 10.7.2';


### PR DESCRIPTION
I got the user agent from a IE11 on windows 7 vm from here: http://www.modern.ie/en-us/virtualization-tools
It was being detected as firefox, this corrects that.
