### PR TITLE
provide support for MS Surface RT

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -418,6 +418,7 @@
       'PlayStation 3',
       'PlayStation 4',
       'PlayStation Vita',
+      { 'label': 'Surface RT', 'pattern': 'Tablet PC 2.0'},
       'TouchPad',
       'Transformer',
       { 'label': 'Wii U', 'pattern': 'WiiU' },
@@ -701,6 +702,12 @@
       name = 'IE Mobile';
       os = 'Windows Phone 8.x';
       description.unshift('desktop mode');
+      version || (version = (/\brv:([\d.]+)/.exec(ua) || 0)[1]);
+    }
+    // Detect IE 11 Mobile (Surface).
+    else if (/\bTablet PC\b/i.test(ua)) {
+      name = 'IE Mobile';
+      os = 'Windows RT 8.1';
       version || (version = (/\brv:([\d.]+)/.exec(ua) || 0)[1]);
     }
     // Detect IE 11.

--- a/test/test.js
+++ b/test/test.js
@@ -1336,6 +1336,15 @@
       'version': '11.0'
     },
 
+    'IE Mobile 11.0 on Surface RT (Windows RT 8.1)': {
+      'ua': 'Mozilla/5.0 (Windows NT 6.3; ARM; Trident/7.0; Touch; .NET4.0E; .NET4.0C; Tablet PC 2.0; rv:11.0) like Gecko',
+      'layout': 'Trident',
+      'name': 'IE Mobile',
+      'os': 'Windows RT 8.1',
+      'product': 'Surface RT',
+      'version': '11.0'
+    },
+
     'SRWare Iron 0.2.152.0 on Windows Vista / Server 2008': {
       'ua': 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US) AppleWebKit/525.19 (KHTML, like Gecko) Iron/0.2.152.0 Safari/41562480.525',
       'layout': 'WebKit',


### PR DESCRIPTION
I didn't get it the `manufacturer` working, I tried it to extends the object defined when calling `getManufacturer` like this:

`      'Microsoft': { 'Xbox': 1, 'Xbox One': 1, 'Tablet PC': 1 },`

but `manufacturer` is still null, so I omit the manufacturer.