### PR TITLE
Detect if this is Chrome on Mac and set architecture to 64

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -965,6 +965,10 @@
         description.unshift('32-bit');
       }
     }
+    else if (os && (os.family.indexOf('OS X') != -1 || os.family.indexOf('Mac') != -1) &&
+        name == "Chrome" && parseFloat(version) >= 39) {
+        os.architecture = 64;
+    }
 
     ua || (ua = null);
 

--- a/platform.js
+++ b/platform.js
@@ -965,6 +965,7 @@
         description.unshift('32-bit');
       }
     }
+    // Detect if this is Mac on Chrome. Architecture is always 64bit on Chrome 39 and above
     else if (os && (os.family.indexOf('OS X') != -1 || os.family.indexOf('Mac') != -1) &&
         name == "Chrome" && parseFloat(version) >= 39) {
         os.architecture = 64;

--- a/test/test.js
+++ b/test/test.js
@@ -2301,7 +2301,17 @@
       'ua': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7 Prism/1.0b2',
       'layout': 'Gecko',
       'os': 'Windows XP'
+    },
+
+    'Chrome 49.0.2623.87 on OS X 10.11.1 64-bit': {
+      'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36',
+      'layout': 'Blink',
+      'name': 'Chrome',
+      'os': 'OS X 10.11.1 64-bit',
+      'version': '49.0.2623.87',
+      'architecture': 64
     }
+
   };
 
   /*--------------------------------------------------------------------------*/
@@ -2319,6 +2329,15 @@
         });
       });
     });
+
+    QUnit.test('has the correct architecture values', function(assert) {
+      forOwn(Tests, function(value, key) {
+        if (value.hasOwnProperty("architecture")) {
+          var platform = getPlatform(key, value)
+          assert.strictEqual(platform.os.architecture, value.architecture, 'platform.' + key)
+        }
+      })
+    })
 
     QUnit.test('has correct null values', function(assert) {
       forOwn(Tests, function(value, key) {


### PR DESCRIPTION
On version 39 of Chrome and above only 64bit is supported on Mac [(see here)](http://googleappsupdates.blogspot.com.au/2014/09/google-chrome-64-bit-for-mac-and-windows.html)

This change, detects this and set os.architecture accordingly.
