### PR TITLE
device Archos 40 Cesium detects as iPhone iOS

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -399,6 +399,7 @@
 
     /* Detectable products (order is important). */
     var product = getProduct([
+      'Archos',
       { 'label': 'BlackBerry', 'pattern': 'BB10' },
       'BlackBerry',
       { 'label': 'Galaxy S', 'pattern': 'GT-I9000' },
@@ -430,6 +431,7 @@
     /* Detectable manufacturers. */
     var manufacturer = getManufacturer({
       'Apple': { 'iPad': 1, 'iPhone': 1, 'iPod': 1 },
+      'Archos': { '40 Cesium': 1, '50 Cesium': 1, 'Helium': 1 },
       'Amazon': { 'Kindle': 1, 'Kindle Fire': 1 },
       'Asus': { 'Transformer': 1 },
       'Barnes & Noble': { 'Nook': 1 },

--- a/test/test.js
+++ b/test/test.js
@@ -1323,6 +1323,16 @@
       'product': 'Lumia 920',
       'version': '11.0'
     },
+    
+    'IE Mobile 11.0 on Archos 40 Cesium (Windows Phone 8.1)': {
+      'ua': 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; ARCHOS; 40 Cesium) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537',
+      'layout': 'Trident',
+      'manufacturer': 'Archos',
+      'name': 'IE Mobile',
+      'os': 'Windows Phone 8.1',
+      'product': 'Archos',
+      'version': '11.0'
+    },
 
     'IE Mobile 11.0 (desktop mode) on Nokia Lumia 920 (Windows Phone 8.x)': {
       'ua': 'Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; Lumia 920) like Gecko',

--- a/test/test.js
+++ b/test/test.js
@@ -1324,7 +1324,7 @@
       'version': '11.0'
     },
     
-    'IE Mobile 11.0 on Archos 40 Cesium (Windows Phone 8.1)': {
+    'IE Mobile 11.0 on Archos (Windows Phone 8.1)': {
       'ua': 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; ARCHOS; 40 Cesium) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537',
       'layout': 'Trident',
       'manufacturer': 'Archos',


### PR DESCRIPTION
I tested platform.js on several devices and found that a device called Archos 40 Cesium, running Windows Phone 8.1, is incorrectly detected as iPhone iOS 7.0.3.

I've fixed this by adding 'Archos' to the arrays passed to getProduct and getManufacturer, and the os and device are then detected correctly.

Note: I've also added the device types 'Cesium' and 'Helium' although I don't know how this is supposed to work exactly.
