### PR TITLE
make it usable with meteor

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -733,7 +733,7 @@
             }
           }
         }
-        else if (typeof context.process == 'object' && (data = context.process)) {
+        else if (typeof context.process == 'object' && !context.process.browser && (data = context.process)) {
           name = 'Node.js';
           arch = data.arch;
           os = data.platform;


### PR DESCRIPTION
- closes #109

The platform package does the following to check for Node but since process is defined as an object because of the process module it's inadvertently classifying itself as Node in this step and then failing when it tries to grab the numeric version of the process.version (which is just an empty string).
