### PR TITLE
Unbreak embedded IE

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -843,8 +843,14 @@
       name += ' Mobile';
     }
     // Detect IE platform preview.
-    else if (name == 'IE' && useFeatures && context.external === null) {
-      description.unshift('platform preview');
+    else if (name == 'IE' && useFeatures) {
+      try {
+        if (context.external === null) {
+          description.unshift('platform preview');
+        }
+      } catch(e) {
+        description.unshift('embedded');
+      }
     }
     // Detect BlackBerry OS version.
     // http://docs.blackberry.com/en/developers/deliverables/18169/HTTP_headers_sent_by_BB_Browser_1234911_11.jsp


### PR DESCRIPTION
Embedded IE throws when reading "window.external"
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=151165