### PR TITLE
run minifier in prepublish script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 node_modules
+platform.min.js*

--- a/package.json
+++ b/package.json
@@ -14,15 +14,19 @@
   "repository": "bestiejs/platform.js",
   "scripts": {
     "doc": "docdown platform.js doc/README.md style=github title=\"Platform.js <sup>v${npm_package_version}</sup>\" toc=properties url=https://github.com/bestiejs/platform.js/blob/${npm_package_version}/platform.js",
+    "prepublish": "uglifyjs platform.js --compress --mangle --output platform.min.js --source-map platform.min.js.map",
     "test": "node test/test"
   },
   "devDependencies": {
     "docdown": "~0.7.1",
     "qunit-extras": "^1.5.0",
     "qunitjs": "~1.22.0",
-    "requirejs": "^2.3.2"
+    "requirejs": "^2.3.2",
+    "uglify-js": "^2.7.5"
   },
   "files": [
-    "platform.js"
+    "platform.js",
+    "platform.min.js",
+    "platform.min.js.map"
   ]
 }


### PR DESCRIPTION
It would be great if [jsdelivr.com](https://www.jsdelivr.com) could serve a minified version of this library ([cdnjs.com](https://www.cdnjs.com) currently does, using a minifier script in-house). I added minification to the `prepublish` script, which should not cause any unnecessary change to existing workflows, and results in NPM delivering both versions of the library. I also added the new files to `.gitignore`, hopefully making this change an unobtrusive as possible. Thanks for considering! 

Would close https://github.com/bestiejs/platform.js/issues/115.