### PR TITLE
Fix unkown nodejs version

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -772,7 +772,8 @@
             name = 'Node.js';
             arch = data.arch;
             os = data.platform;
-            version = /[\d.]+/.exec(data.version)[0];
+            version = /[\d.]+/.exec(data.version)
+            version = version ? version[0] : 'unknown';
           }
         }
         else if (rhino) {


### PR DESCRIPTION
When running in react-native, the version property is no available, this
fix will make the library not crash in those scenarios.