### PR TITLE
test name if it's still null, default node.js

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -768,7 +768,8 @@
               name = 'NW.js';
               version = data.versions.nw;
             }
-          } else {
+          } 
+          if (!name) {
             name = 'Node.js';
             arch = data.arch;
             os = data.platform;


### PR DESCRIPTION
The new test for versions for 'nw' doesn't have a default case if versions is an object, but does not have 'nw'
should fix #125

Making PR to test; will update comment after.