### PR TITLE
test name if it's still null, default node.js

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -768,7 +768,8 @@
               name = 'NW.js';
               version = data.versions.nw;
             }
-          } else {
+          } 
+          if (!name) {
             name = 'Node.js';
             arch = data.arch;
             os = data.platform;


### PR DESCRIPTION
#130
The new test for versions for 'nw' doesn't have a default case if versions is an object, but does not have 'nw'

Although the previous one shows it was merged, the code is still missing from the head.  Someone using it tried github head and it didn't work, they tried my patch-1 branch and it did work.  

https://github.com/bestiejs/platform.js/compare/master...d3x0r:patch-1