### PR TITLE
Fix #132 - Add Chrome Headless detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ info.description; // 'Opera 11.52 (identifying as Firefox 4.0) on Mac OS X 10.7.
 
 ## Support
 
-Tested in Chrome 53-54, Firefox 48-49, IE 11, Edge 14, Safari 9-10, Node.js 4-7, & PhantomJS 2.1.1.
+Tested in Chrome 53-54, Chrome Headless 63, Firefox 48-49, IE 11, Edge 14, Safari 9-10, Node.js 4-7, & PhantomJS 2.1.1.
 
 ## BestieJS
 

--- a/platform.js
+++ b/platform.js
@@ -392,6 +392,7 @@
       'Opera',
       { 'label': 'Opera', 'pattern': 'OPR' },
       'Chrome',
+      { 'label': 'Chrome', 'pattern': '(?:HeadlessChrome)' },
       { 'label': 'Chrome Mobile', 'pattern': '(?:CriOS|CrMo)' },
       { 'label': 'Firefox', 'pattern': '(?:Firefox|Minefield)' },
       { 'label': 'Firefox for iOS', 'pattern': 'FxiOS' },
@@ -697,6 +698,7 @@
       version = getVersion([
         '(?:Cloud9|CriOS|CrMo|Edge|FxiOS|IEMobile|Iron|Opera ?Mini|OPiOS|OPR|Raven|SamsungBrowser|Silk(?!/[\\d.]+$))',
         'Version',
+        'HeadlessChrome',
         qualify(name),
         '(?:Firefox|Minefield|NetFront)'
       ]);
@@ -919,7 +921,7 @@
         version = null;
       }
       // Use the full Chrome version when available.
-      data[1] = (/\bChrome\/([\d.]+)/i.exec(ua) || 0)[1];
+      data[1] = (/\b(?:Headless)?Chrome\/([\d.]+)/i.exec(ua) || 0)[1];
       // Detect Blink layout engine.
       if (data[0] == 537.36 && data[2] == 537.36 && parseFloat(data[1]) >= 28 && layout == 'WebKit') {
         layout = ['Blink'];

--- a/test/test.js
+++ b/test/test.js
@@ -569,6 +569,22 @@
       'version': '54.0.2840.71'
     },
 
+    'Chrome 63.0.3239.132 on OS X 10.11.6 64-bit': {
+      'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/63.0.3239.132 Safari/537.36',
+      'layout': 'Blink',
+      'name': 'Chrome',
+      'os': 'OS X 10.11.6 64-bit',
+      'version': '63.0.3239.132'
+    },
+
+    'Chrome 63.0.3239.132 on Linux 64-bit': {
+      'ua': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/63.0.3239.132 Safari/537.36',
+      'layout': 'Blink',
+      'name': 'Chrome',
+      'os': 'Linux 64-bit',
+      'version': '63.0.3239.132'
+    },
+
     'Chrome Mobile 16.0.912.77 on HTC (Android 4.0.3)': {
       'ua': 'Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC Sensation XE with Beats Audio Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.77 Mobile Safari/535.7',
       'layout': 'WebKit',


### PR DESCRIPTION
Add Chrome Headless support as Chrome browser to keep it simple
for others to see as Chrome per Issue #127.