### PR TITLE
Add Edge iOS and Edge Android browser detection

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -339,7 +339,7 @@
 
     /* Detectable layout engines (order is important). */
     var layout = getLayout([
-      { 'label': 'EdgeHTML', 'pattern': 'Edge' },
+      { 'label': 'EdgeHTML', 'pattern': '(?:Edge|EdgA|EdgiOS)' },
       'Trident',
       { 'label': 'WebKit', 'pattern': 'AppleWebKit' },
       'iCab',
@@ -369,9 +369,7 @@
       'Konqueror',
       'Lunascape',
       'Maxthon',
-      { 'label': 'Microsoft Edge', 'pattern': 'Edge' },
-      { 'label': 'Microsoft Edge', 'pattern': 'EdgA' },
-      { 'label': 'Microsoft Edge', 'pattern': 'EdgiOS' },
+      { 'label': 'Microsoft Edge', 'pattern': '(?:Edge|EdgA|EdgiOS)' },
       'Midori',
       'Nook Browser',
       'PaleMoon',
@@ -697,7 +695,7 @@
     // Detect non-Opera (Presto-based) versions (order is important).
     if (!version) {
       version = getVersion([
-        '(?:Cloud9|CriOS|CrMo|Edge|FxiOS|IEMobile|Iron|Opera ?Mini|OPiOS|OPR|Raven|SamsungBrowser|Silk(?!/[\\d.]+$))',
+        '(?:Cloud9|CriOS|CrMo|Edge|EdgA|EdgiOS|FxiOS|IEMobile|Iron|Opera ?Mini|OPiOS|OPR|Raven|SamsungBrowser|Silk(?!/[\\d.]+$))',
         'Version',
         qualify(name),
         '(?:Firefox|Minefield|NetFront)'

--- a/platform.js
+++ b/platform.js
@@ -370,6 +370,8 @@
       'Lunascape',
       'Maxthon',
       { 'label': 'Microsoft Edge', 'pattern': 'Edge' },
+      { 'label': 'Microsoft Edge', 'pattern': 'EdgA' },
+      { 'label': 'Microsoft Edge', 'pattern': 'EdgiOS' },
       'Midori',
       'Nook Browser',
       'PaleMoon',

--- a/test/test.js
+++ b/test/test.js
@@ -1693,11 +1693,13 @@
       'version': '41.1.35.1'
     },
 
-    'Microsoft Edge 41.1.35.1 on Android 8.0': {
-      'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
+    'Microsoft Edge 41.1.35.1 on Google Nexus 9 (Android 8.0)': {
+      'ua': 'Mozilla/5.0 (Linux; Android 8.0; Google Nexus 9 - 5.1.0 - API 22 - 1536x2048 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
       'layout': 'EdgeHTML',
+      'manufacturer': 'Google',
       'name': 'Microsoft Edge',
       'os': 'Android 8.0',
+      'product': 'Nexus 9',
       'version': '41.1.35.1'
     },
       

--- a/test/test.js
+++ b/test/test.js
@@ -1688,12 +1688,12 @@
       'layout': 'EdgeHTML',
       'manufacturer': 'Apple',
       'name': 'Microsoft Edge',
-      'os': 'iOS',
+      'os': 'iOS 10.3.2',
       'product': 'iPhone',
       'version': '41.1.35.1'
     },
 
-    'Microsoft Edge Mobile 41.1.35.1 on Android 8.0': {
+    'Microsoft Edge 41.1.35.1 on Android 8.0': {
       'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
       'layout': 'EdgeHTML',
       'name': 'Microsoft Edge',

--- a/test/test.js
+++ b/test/test.js
@@ -1683,7 +1683,7 @@
       'version': '13.10586'
     },
     
-    'Microsoft Edge 41.1.35.1 for iOS': {
+    'Microsoft Edge 41.1.35.1 (like Safari 8+) on Apple iPhone (iOS 10.3.2)': {
       'ua': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1',
       'layout': 'EdgeHTML',
       'manufacturer': 'Apple',
@@ -1693,7 +1693,7 @@
       'version': '41.1.35.1'
     },
 
-    'Microsoft Edge 41.1.35.1 for Android': {
+    'Microsoft Edge Mobile 41.1.35.1 on Android 8.0': {
       'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
       'layout': 'EdgeHTML',
       'manufacturer': 'Apple',

--- a/test/test.js
+++ b/test/test.js
@@ -1696,7 +1696,6 @@
     'Microsoft Edge Mobile 41.1.35.1 on Android 8.0': {
       'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
       'layout': 'EdgeHTML',
-      'manufacturer': 'Apple',
       'name': 'Microsoft Edge',
       'os': 'Android 8.0',
       'version': '41.1.35.1'

--- a/test/test.js
+++ b/test/test.js
@@ -1682,7 +1682,26 @@
       'product': 'Lumia 950',
       'version': '13.10586'
     },
+    
+    'Microsoft Edge 41.1.35.1 for iOS': {
+      'ua': 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1',
+      'layout': 'EdgeHTML',
+      'manufacturer': 'Apple',
+      'name': 'Microsoft Edge',
+      'os': 'iOS',
+      'product': 'iPhone',
+      'version': '41.1.35.1'
+    ),
 
+    'Microsoft Edge 41.1.35.1 for Android': {
+      'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
+      'layout': 'EdgeHTML',
+      'manufacturer': 'Apple',
+      'name': 'Microsoft Edge',
+      'os': 'Android 8.0',
+      'version': '41.1.35.1'
+    ),
+      
     'Midori (like Safari 3.x) on Linux 64-bit': {
       'ua': 'Mozilla/5.0 (X11; U; Linux x86_64; ru-ru) AppleWebKit/525.1+ (KHTML, like Gecko, Safari/525.1+) midori',
       'layout': 'WebKit',

--- a/test/test.js
+++ b/test/test.js
@@ -1691,7 +1691,7 @@
       'os': 'iOS',
       'product': 'iPhone',
       'version': '41.1.35.1'
-    ),
+    },
 
     'Microsoft Edge 41.1.35.1 for Android': {
       'ua': 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1',
@@ -1700,7 +1700,7 @@
       'name': 'Microsoft Edge',
       'os': 'Android 8.0',
       'version': '41.1.35.1'
-    ),
+    },
       
     'Midori (like Safari 3.x) on Linux 64-bit': {
       'ua': 'Mozilla/5.0 (X11; U; Linux x86_64; ru-ru) AppleWebKit/525.1+ (KHTML, like Gecko, Safari/525.1+) midori',


### PR DESCRIPTION
Add Edge iOS and Edge Android browser name detection based on the information from Microsoft.

https://blogs.windows.com/msedgedev/2017/10/05/microsoft-edge-ios-android-developer/